### PR TITLE
Add docs for mini-app setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,46 @@
 # lex-app-plugins
-Monorepo for Lex App plugin system
+
+This repository contains the building blocks for the **Lex App** plugin ecosystem. Mini-apps are distributed as small Docker images and registered with a manifest describing how they integrate with the host application.
+
+## Setup
+
+1. Install [Docker](https://docs.docker.com/get-docker/) so you can build and run mini-app containers.
+2. Clone this repository:
+
+```bash
+git clone <repo-url>
+cd lex-app-plugins
+```
+
+Node.js is only required if you plan to develop the Builder Portal or Catalog API services.
+
+## Directory layout
+
+- `mini-app-template/` – example mini-app containing `index.html`, a `manifest.json` and a `Dockerfile`.
+- `builder-portal/` – (future) web interface for publishing and managing mini-apps.
+- `catalog-api/` – (future) API service that exposes registered mini-apps.
+- `schema/` – JSON schema used to validate each mini-app's `manifest.json`.
+- `.github/workflows/` – CI that builds the example mini-app and pushes it to GHCR.
+
+### `/apps` convention
+
+All mini-apps are mounted under `/apps/<appId>`. The `routes` field in `manifest.json` must follow this convention. The example template registers the path `/apps/hello-world`.
+
+## Adding or building a mini-app
+
+1. Copy `mini-app-template` to a new folder named after your `appId`.
+2. Edit `manifest.json` – set a unique `appId`, update the `version`, and adjust the `routes` array to include your `/apps/...` path.
+3. Customize the app's source files (e.g. `index.html` or any front-end framework).
+4. Build the Docker image:
+
+```bash
+docker build -t ghcr.io/<owner>/lex-app-plugins/<appId>:<version> path/to/your-app
+```
+
+5. (Optional) run the container locally:
+
+```bash
+docker run -p 5000:80 ghcr.io/<owner>/lex-app-plugins/<appId>:<version>
+```
+
+Updates to `mini-app-template/manifest.json` automatically trigger the GitHub Actions workflow that builds and pushes the sample image.

--- a/builder-portal/README.md
+++ b/builder-portal/README.md
@@ -1,1 +1,16 @@
 # builder-portal
+
+The Builder Portal will be a web interface for uploading and managing mini-apps.
+It currently contains no source code, but when implemented it will likely be a
+Node/React application.
+
+## Running locally (when code exists)
+
+```bash
+cd builder-portal
+npm install
+npm start
+```
+
+The portal will help package your app and publish its `manifest.json` so that the
+Catalog API can serve it.

--- a/catalog-api/README.md
+++ b/catalog-api/README.md
@@ -1,1 +1,16 @@
 # catalog-api
+
+This directory is reserved for the service that will expose a catalog of
+available mini-apps. The API will serve the `manifest.json` files so the host
+application can discover and load apps.
+
+## Running locally (when code exists)
+
+```bash
+cd catalog-api
+npm install
+npm start
+```
+
+At the moment there is no implementation, but this folder documents where the
+Catalog API will live.


### PR DESCRIPTION
## Summary
- document how to build mini-apps and explain `/apps` routing convention
- add notes to builder-portal and catalog-api READMEs

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6848912279cc832fa15096595e09c5c2